### PR TITLE
Added functionality for issue #89 and 100% test coverage

### DIFF
--- a/packages/app/obojobo-document-engine/__tests__/Viewer/components/__snapshots__/nav.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/components/__snapshots__/nav.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Nav renders all list item types (locked=false) 1`] = `
 <nav
   aria-label="Navigation"
-  className="viewer--components--nav is-not-locked is-not-open is-enabled"
+  className="viewer--components--nav is-not-locked is-not-open is-enabled is-not-red-alert"
   role="navigation"
   tabIndex="-1"
 >
@@ -17,6 +17,18 @@ exports[`Nav renders all list item types (locked=false) 1`] = `
       onClick={[Function]}
     >
       Skip Navigation
+    </button>
+  </div>
+  <div
+    className="obojobo-draft--components--button alt-action is-not-dangerous align-center red-alert"
+  >
+    <button
+      className="button"
+      contentEditable={false}
+      disabled={true}
+      onClick={[Function]}
+    >
+      Red Alert
     </button>
   </div>
   <button
@@ -129,7 +141,7 @@ exports[`Nav renders all list item types (locked=false) 1`] = `
 exports[`Nav renders all list item types (locked=true) 1`] = `
 <nav
   aria-label="Navigation"
-  className="viewer--components--nav is-locked is-not-open is-enabled"
+  className="viewer--components--nav is-locked is-not-open is-enabled is-not-red-alert"
   role="navigation"
   tabIndex="-1"
 >
@@ -143,6 +155,18 @@ exports[`Nav renders all list item types (locked=true) 1`] = `
       onClick={[Function]}
     >
       Skip Navigation
+    </button>
+  </div>
+  <div
+    className="obojobo-draft--components--button alt-action is-not-dangerous align-center red-alert"
+  >
+    <button
+      className="button"
+      contentEditable={false}
+      disabled={true}
+      onClick={[Function]}
+    >
+      Red Alert
     </button>
   </div>
   <button
@@ -276,7 +300,7 @@ exports[`Nav renders all list item types (locked=true) 1`] = `
 exports[`Nav renders closed 1`] = `
 <nav
   aria-label="Navigation"
-  className="viewer--components--nav is-locked is-open is-enabled"
+  className="viewer--components--nav is-locked is-open is-enabled is-not-red-alert"
   role="navigation"
   tabIndex="-1"
 >
@@ -289,6 +313,17 @@ exports[`Nav renders closed 1`] = `
       onClick={[Function]}
     >
       Skip Navigation
+    </button>
+  </div>
+  <div
+    className="obojobo-draft--components--button alt-action is-not-dangerous align-center red-alert"
+  >
+    <button
+      className="button"
+      contentEditable={false}
+      onClick={[Function]}
+    >
+      Red Alert
     </button>
   </div>
   <button
@@ -313,7 +348,7 @@ exports[`Nav renders closed 1`] = `
 exports[`Nav renders opened 1`] = `
 <nav
   aria-label="Navigation"
-  className="viewer--components--nav is-locked is-not-open is-enabled"
+  className="viewer--components--nav is-locked is-not-open is-enabled is-not-red-alert"
   role="navigation"
   tabIndex="-1"
 >
@@ -327,6 +362,18 @@ exports[`Nav renders opened 1`] = `
       onClick={[Function]}
     >
       Skip Navigation
+    </button>
+  </div>
+  <div
+    className="obojobo-draft--components--button alt-action is-not-dangerous align-center red-alert"
+  >
+    <button
+      className="button"
+      contentEditable={false}
+      disabled={true}
+      onClick={[Function]}
+    >
+      Red Alert
     </button>
   </div>
   <button
@@ -351,7 +398,7 @@ exports[`Nav renders opened 1`] = `
 exports[`Nav renders unlocked 1`] = `
 <nav
   aria-label="Navigation"
-  className="viewer--components--nav is-not-locked is-not-open is-enabled"
+  className="viewer--components--nav is-not-locked is-not-open is-enabled is-not-red-alert"
   role="navigation"
   tabIndex="-1"
 >
@@ -365,6 +412,18 @@ exports[`Nav renders unlocked 1`] = `
       onClick={[Function]}
     >
       Skip Navigation
+    </button>
+  </div>
+  <div
+    className="obojobo-draft--components--button alt-action is-not-dangerous align-center red-alert"
+  >
+    <button
+      className="button"
+      contentEditable={false}
+      disabled={true}
+      onClick={[Function]}
+    >
+      Red Alert
     </button>
   </div>
   <button

--- a/packages/app/obojobo-document-engine/__tests__/Viewer/components/nav.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/components/nav.test.js
@@ -53,6 +53,7 @@ jest.mock('../../../src/scripts/viewer/util/nav-util', () => ({
 	toggle: jest.fn(),
 	getOrderedList: jest.fn(),
 	getNavTarget: jest.fn(),
+	setRedAlert: jest.fn(),
 	close: jest.fn(),
 	open: jest.fn()
 }))
@@ -250,6 +251,38 @@ describe('Nav', () => {
 		el.find('li').simulate('click')
 		expect(FocusUtil.focusComponent).toHaveBeenCalledTimes(1)
 		expect(FocusUtil.focusComponent).toHaveBeenCalledWith(5, { animateScroll: true })
+	})
+
+	test('test that onRedAlertClick was called by clicking red alert button', () => {
+		NavUtil.getOrderedList.mockReturnValueOnce([])
+
+		const props = {
+			navState: {
+				open: false,
+				locked: true,
+				redAlert: false
+			}
+		}
+		const el = shallow(<Nav {...props} />)
+		el.find('.red-alert').simulate('click')
+		expect(NavUtil.setRedAlert).toHaveBeenCalledWith(true)
+		expect(NavUtil.setRedAlert).toHaveBeenCalledTimes(1)
+	})
+
+	test('test that clicking red alert button causes red alert mode to be set to false', () => {
+		NavUtil.getOrderedList.mockReturnValueOnce([])
+
+		const props = {
+			navState: {
+				open: false,
+				locked: true,
+				redAlert: true
+			}
+		}
+		const el = shallow(<Nav {...props} />)
+		el.find('.red-alert').simulate('click')
+		expect(NavUtil.setRedAlert).toHaveBeenCalledWith(false)
+		expect(NavUtil.setRedAlert).toHaveBeenCalledTimes(1)
 	})
 
 	test('onClickSkipNavigation calls FocusUtil.focusOnNavTarget', () => {

--- a/packages/app/obojobo-document-engine/__tests__/Viewer/stores/__snapshots__/nav-store.test.js.snap
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/stores/__snapshots__/nav-store.test.js.snap
@@ -12,6 +12,7 @@ Object {
   "nav:openExternalLink": [Function],
   "nav:prev": [Function],
   "nav:rebuildMenu": [Function],
+  "nav:redAlert": [Function],
   "nav:resetContext": [Function],
   "nav:setContext": [Function],
   "nav:setFlag": [Function],
@@ -276,6 +277,7 @@ Object {
   "navTargetHistory": Array [],
   "navTargetId": null,
   "open": true,
+  "redAlert": false,
   "visitId": 11,
 }
 `;
@@ -292,6 +294,7 @@ Object {
   "navTargetHistory": Array [],
   "navTargetId": null,
   "open": true,
+  "redAlert": false,
   "visitId": 11,
 }
 `;
@@ -308,6 +311,7 @@ Object {
   "navTargetHistory": Array [],
   "navTargetId": null,
   "open": true,
+  "redAlert": false,
   "visitId": 11,
 }
 `;
@@ -495,6 +499,64 @@ Array [
 `;
 
 exports[`NavStore nav:prev does not change to invalid page 1`] = `undefined`;
+
+exports[`NavStore nav:redAlert sends post event, red alert being false 1`] = `
+Array [
+  "navstore:change",
+]
+`;
+
+exports[`NavStore nav:redAlert sends post event, red alert being false 2`] = `
+Array [
+  Object {
+    "action": "nav:redAlert:disable",
+    "draftId": "mockDraftId",
+    "eventVersion": "1.0.0",
+    "payload": Object {
+      "from": false,
+      "to": false,
+    },
+    "visitId": "mockVisitId",
+  },
+]
+`;
+
+exports[`NavStore nav:redAlert sends post event, red alert being false 3`] = `
+Object {
+  "draftId": "mockDraftId",
+  "redAlert": false,
+  "visitId": "mockVisitId",
+}
+`;
+
+exports[`NavStore nav:redAlert sends post event, red alert being true 1`] = `
+Array [
+  "navstore:change",
+]
+`;
+
+exports[`NavStore nav:redAlert sends post event, red alert being true 2`] = `
+Array [
+  Object {
+    "action": "nav:redAlert:enable",
+    "draftId": "mockDraftId",
+    "eventVersion": "1.0.0",
+    "payload": Object {
+      "from": true,
+      "to": true,
+    },
+    "visitId": "mockVisitId",
+  },
+]
+`;
+
+exports[`NavStore nav:redAlert sends post event, red alert being true 3`] = `
+Object {
+  "draftId": "mockDraftId",
+  "redAlert": true,
+  "visitId": "mockVisitId",
+}
+`;
 
 exports[`NavStore nav:setFlag event updates state and calls trigger 1`] = `
 Object {

--- a/packages/app/obojobo-document-engine/__tests__/Viewer/stores/nav-store.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/stores/nav-store.test.js
@@ -500,6 +500,44 @@ describe('NavStore', () => {
 		expect(NavUtil.setFlag.mock.calls[0]).toMatchSnapshot()
 	})
 
+	test('nav:redAlert sends post event, red alert being true', () => {
+		NavStore.setState({
+			draftId: 'mockDraftId',
+			visitId: 'mockVisitId',
+			redAlert: true
+		})
+		// simulate trigger
+		Dispatcher.trigger.mockReturnValueOnce()
+
+		// go
+		eventCallbacks['nav:redAlert']({ value: { redAlert: true } })
+
+		expect(Dispatcher.trigger).toHaveBeenCalledTimes(1)
+		expect(Dispatcher.trigger.mock.calls[0]).toMatchSnapshot()
+		expect(APIUtil.postEvent).toHaveBeenCalledTimes(1)
+		expect(APIUtil.postEvent.mock.calls[0]).toMatchSnapshot()
+		expect(NavStore.getState()).toMatchSnapshot()
+	})
+
+	test('nav:redAlert sends post event, red alert being false', () => {
+		NavStore.setState({
+			draftId: 'mockDraftId',
+			visitId: 'mockVisitId',
+			redAlert: false
+		})
+		// simulate trigger
+		Dispatcher.trigger.mockReturnValueOnce()
+
+		// go
+		eventCallbacks['nav:redAlert']({ value: { redAlert: false } })
+
+		expect(Dispatcher.trigger).toHaveBeenCalledTimes(1)
+		expect(Dispatcher.trigger.mock.calls[0]).toMatchSnapshot()
+		expect(APIUtil.postEvent).toHaveBeenCalledTimes(1)
+		expect(APIUtil.postEvent.mock.calls[0]).toMatchSnapshot()
+		expect(NavStore.getState()).toMatchSnapshot()
+	})
+
 	test('question:scoreSet sets flag with a score of 100', () => {
 		NavStore.setState({ itemsById: { mockID: { showChildren: 'unchanged' } } })
 		// simulate trigger
@@ -548,6 +586,32 @@ describe('NavStore', () => {
 		NavUtil.getFirst.mockReturnValueOnce(undefined) //eslint-disable-line
 		NavStore.init('mockDraftId', null, null, 'startingpath', 11)
 		expect(NavUtil.goto).not.toHaveBeenCalledWith()
+	})
+
+	test('init stores redAlert value in the state', () => {
+		NavStore.init('mockDraftId', null, 12, '', 11, {}, true)
+		expect(NavStore.getState()).toHaveProperty('redAlert', true)
+
+		NavStore.init('mockDraftId', null, 12, '', 11, {})
+		expect(NavStore.getState()).toHaveProperty('redAlert', false)
+		/*
+		expect(NavStore.getState()).toMatchInlineSnapshot(`
+		Object {
+		  "context": "practice",
+		  "draftId": "mockDraftId",
+		  "items": Object {},
+		  "itemsByFullPath": Object {},
+		  "itemsById": Object {},
+		  "itemsByPath": Object {},
+		  "locked": false,
+		  "navTargetHistory": Array [],
+		  "navTargetId": null,
+		  "open": true,
+		  "redAlert": true,
+		  "visitId": 11,
+		}
+	`)
+	*/
 	})
 
 	test('buildMenu should reset menu items', () => {

--- a/packages/app/obojobo-document-engine/__tests__/Viewer/util/nav-util.test.js
+++ b/packages/app/obojobo-document-engine/__tests__/Viewer/util/nav-util.test.js
@@ -78,6 +78,35 @@ describe('NavUtil', () => {
 		expect(x).toBe('mockTriggerReturn')
 	})
 
+	test('setRedAlert', () => {
+		expect(Common.flux.Dispatcher.trigger).not.toHaveBeenCalled()
+		const x = NavUtil.setRedAlert('mockRedAlert')
+		const expectedValue = { value: { redAlert: 'mockRedAlert' } }
+		expect(Common.flux.Dispatcher.trigger).toHaveBeenCalledWith('nav:redAlert', expectedValue)
+		expect(x).toBe('mockTriggerReturn')
+	})
+
+	// this one and the next one do the same thing, but the object version is more rigourous
+	test('isRedAlertEnabled', () => {
+		const state = { redAlert: 'enabled' }
+		const x = NavUtil.isRedAlertEnabled(state)
+		expect(x).toBe('enabled')
+	})
+
+	test('isRedAlertEnabled', () => {
+		const testObj = {}
+		const state = { redAlert: testObj }
+		const x = NavUtil.isRedAlertEnabled(state)
+		expect(x).toBe(testObj)
+	})
+
+	// toBe uses === for comparison, toEqual uses ==
+	test('isRedAlertEnabled', () => {
+		const state = { redAlert: {} }
+		const x = NavUtil.isRedAlertEnabled(state)
+		expect(x).toEqual({})
+	})
+
 	test('setFlag', () => {
 		expect(Common.flux.Dispatcher.trigger).not.toHaveBeenCalled()
 		const x = NavUtil.setFlag('mockId', 'mockFlagName', 'mockFlagValue')

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.js
@@ -24,6 +24,7 @@ export default class Nav extends React.Component {
 		this.selfRef = React.createRef()
 		this.hideOrShowOnResize = this.hideOrShowOnResize.bind(this)
 		this.closeNavOnMobile = this.closeNavOnMobile.bind(this)
+		this.onRedAlertClick = this.onRedAlertClick.bind(this)
 	}
 
 	isMobileSize() {
@@ -96,6 +97,11 @@ export default class Nav extends React.Component {
 				break
 			}
 		}
+	}
+
+	// set the red alert on the nav
+	onRedAlertClick() {
+		NavUtil.setRedAlert(!this.props.navState.redAlert)
 	}
 
 	focus() {
@@ -194,11 +200,16 @@ export default class Nav extends React.Component {
 		const list = NavUtil.getOrderedList(navState)
 		const lockEl = this.getLockEl(navState.locked)
 		const isNavInaccessible = navState.disabled || !navState.open
+		const isRedAlert = navState.redAlert
+
 		const className =
 			'viewer--components--nav' +
 			isOrNot(navState.locked, 'locked') +
 			isOrNot(navState.open, 'open') +
-			isOrNot(!navState.disabled, 'enabled')
+			isOrNot(!navState.disabled, 'enabled') +
+			isOrNot(isRedAlert, 'red-alert')
+
+		const redAlertButtonText = isRedAlert ? '🚨 Red Alert' : 'Red Alert'
 
 		return (
 			<nav
@@ -216,6 +227,15 @@ export default class Nav extends React.Component {
 					aria-hidden={isNavInaccessible}
 				>
 					Skip Navigation
+				</Button>
+				<Button
+					altAction
+					className="red-alert"
+					disabled={isNavInaccessible}
+					onClick={this.onRedAlertClick}
+					aria-hidden={isNavInaccessible}
+				>
+					{redAlertButtonText}
 				</Button>
 				<button className="toggle-button" onClick={NavUtil.toggle}>
 					Toggle Navigation Menu

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.scss
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/nav.scss
@@ -4,6 +4,7 @@
 	$color-nav-bg: #fbfbfb;
 	$color-nav-highlight: $color-obojobo-blue;
 	$color-nav-hover: darken($color-highlight, 25%);
+	$color-nav-red-alert: red;
 	$padding: 2rem;
 
 	position: fixed;
@@ -164,6 +165,11 @@
 			background: $color-nav-highlight;
 			border: none;
 		}
+	}
+
+	&.is-red-alert {
+		transition: background 2s;
+		background: $color-nav-red-alert;
 	}
 
 	.link {

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/components/viewer-app.js
@@ -118,6 +118,7 @@ export default class ViewerApp extends React.Component {
 		let attemptHistory
 		let viewState
 		let isPreviewing
+		let isRedAlertEnabled
 		let outcomeServiceURL = 'the external system'
 		let viewSessionId
 
@@ -136,6 +137,7 @@ export default class ViewerApp extends React.Component {
 				viewState = visit.value.viewState
 				attemptHistory = visit.value.extensions[':ObojoboDraft.Sections.Assessment:attemptHistory']
 				isPreviewing = visit.value.isPreviewing
+				isRedAlertEnabled = visit.value.isRedAlertEnabled
 				outcomeServiceURL = visit.value.lti.lisOutcomeServiceUrl
 
 				return APIUtil.getDraft(this.props.draftId)
@@ -149,7 +151,8 @@ export default class ViewerApp extends React.Component {
 					model.modelState.start,
 					window.location.pathname,
 					visitIdFromApi,
-					viewState
+					viewState,
+					isRedAlertEnabled
 				)
 				AssessmentStore.init(attemptHistory)
 

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/stores/nav-store.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/stores/nav-store.js
@@ -160,13 +160,42 @@ class NavStore extends Store {
 					if (navItem) {
 						NavUtil.setFlag(payload.value.id, 'correct', payload.value.score === 100)
 					}
+				},
+				'nav:redAlert': payload => {
+					const isRedAlertReallyEnabled = payload.value.redAlert
+					const eventAction = isRedAlertReallyEnabled
+						? 'nav:redAlert:enable'
+						: 'nav:redAlert:disable'
+
+					// send api message
+					APIUtil.postEvent({
+						draftId: this.state.draftId,
+						action: eventAction,
+						eventVersion: '1.0.0',
+						visitId: this.state.visitId,
+						payload: {
+							from: this.state.redAlert,
+							to: payload.value.redAlert
+						}
+					})
+
+					this.state.redAlert = isRedAlertReallyEnabled
+					this.triggerChange()
 				}
 			},
 			this
 		)
 	}
 
-	init(draftId, model, startingId, startingPath, visitId, viewState = {}) {
+	init(
+		draftId,
+		model,
+		startingId,
+		startingPath,
+		visitId,
+		viewState = {},
+		isRedAlertEnabled = false
+	) {
 		this.state = {
 			items: {},
 			itemsById: {},
@@ -174,6 +203,7 @@ class NavStore extends Store {
 			itemsByFullPath: {},
 			navTargetHistory: [],
 			navTargetId: null,
+			redAlert: isRedAlertEnabled,
 			locked:
 				viewState['nav:isLocked'] !== null && typeof viewState['nav:isLocked'] !== 'undefined'
 					? Boolean(viewState['nav:isLocked'].value)

--- a/packages/app/obojobo-document-engine/src/scripts/viewer/util/nav-util.js
+++ b/packages/app/obojobo-document-engine/src/scripts/viewer/util/nav-util.js
@@ -31,6 +31,16 @@ const NavUtil = {
 		})
 	},
 
+	setRedAlert(redAlert) {
+		return Dispatcher.trigger('nav:redAlert', {
+			value: {
+				redAlert
+				// same as:
+				// redAlert: redAlert
+			}
+		})
+	},
+
 	gotoPath(path) {
 		return Dispatcher.trigger('nav:gotoPath', {
 			value: {
@@ -251,6 +261,10 @@ const NavUtil = {
 
 	isNavOpen(state) {
 		return state.open
+	},
+
+	isRedAlertEnabled(state) {
+		return state.redAlert
 	}
 }
 

--- a/packages/app/obojobo-express/__tests__/routes/api/__snapshots__/visits.test.js.snap
+++ b/packages/app/obojobo-express/__tests__/routes/api/__snapshots__/visits.test.js.snap
@@ -4,6 +4,7 @@ exports[`api visits route /start in preview works and doesnt care about matching
 Object {
   "extensions": Object {},
   "isPreviewing": true,
+  "isRedAlertEnabled": false,
   "lti": Object {
     "lisOutcomeServiceUrl": null,
   },

--- a/packages/app/obojobo-express/__tests__/routes/api/visits.test.js
+++ b/packages/app/obojobo-express/__tests__/routes/api/visits.test.js
@@ -390,6 +390,72 @@ describe('api visits route', () => {
 			})
 	})
 
+	test('/start checks that isRedAlertEnabled is being returned from api', () => {
+		expect.assertions(4)
+		// resolve ltiLaunch lookup
+		const launch = {
+			reqVars: {
+				lis_outcome_service_url: 'howtune.com'
+			}
+		}
+		ltiUtil.retrieveLtiLaunch.mockResolvedValueOnce(launch)
+
+		// resolve viewerState.get
+		viewerState.get.mockResolvedValueOnce('view state')
+
+		mockCurrentUser = { id: 99 }
+		mockCurrentDocument = {
+			draftId: validUUID(),
+			yell: jest.fn().mockResolvedValueOnce({ document: 'mock-document' }),
+			contentId: validUUID()
+		}
+		return request(app)
+			.post('/api/start')
+			.send({ visitId: validUUID() })
+			.then(response => {
+				expect(response.header['content-type']).toContain('application/json')
+				expect(response.statusCode).toBe(200)
+				// expect(response.body).toBe('banana')
+				expect(response.body.value).toHaveProperty('isRedAlertEnabled')
+				expect(mockCurrentDocument.yell).toHaveBeenCalledTimes(1)
+			})
+	})
+
+	test('/start checks that isRedAlertEnabled is true', () => {
+		expect.assertions(5)
+		// resolve ltiLaunch lookup
+		const launch = {
+			reqVars: {
+				lis_outcome_service_url: 'howtune.com'
+			}
+		}
+		ltiUtil.retrieveLtiLaunch.mockResolvedValueOnce(launch)
+
+		// resolve viewerState.get
+		viewerState.get.mockResolvedValueOnce('view state')
+
+		// mock return value on select from red_alert_status
+		db.oneOrNone.mockReturnValue({ is_enabled: true })
+
+		mockCurrentUser = { id: 99 }
+		mockCurrentDocument = {
+			draftId: validUUID(),
+			yell: jest.fn().mockResolvedValueOnce({ document: 'mock-document' }),
+			contentId: validUUID()
+		}
+		return request(app)
+			.post('/api/start')
+			.send({ visitId: validUUID() })
+			.then(response => {
+				expect(response.header['content-type']).toContain('application/json')
+				expect(response.statusCode).toBe(200)
+				// expect(response.body).toBe('banana')
+				expect(response.body.value).toHaveProperty('isRedAlertEnabled')
+				expect(response.body.value.isRedAlertEnabled).toBe(true)
+				expect(mockCurrentDocument.yell).toHaveBeenCalledTimes(1)
+			})
+	})
+
 	test('visit:start event and createViewerSessionLoggedInEvent created', () => {
 		expect.assertions(4)
 		// resolve ltiLaunch lookup

--- a/packages/app/obojobo-express/__tests__/viewer_events.test.js
+++ b/packages/app/obojobo-express/__tests__/viewer_events.test.js
@@ -2,6 +2,8 @@ jest.mock('../config')
 jest.mock('../viewer/viewer_state', () => ({ set: jest.fn() }))
 jest.mock('../obo_events', () => ({ on: jest.fn(), emit: jest.fn() }))
 jest.mock('../models/visit')
+jest.mock('../db')
+jest.mock('../logger')
 
 const mockEvent = {
 	userId: 'mockUserId',
@@ -16,6 +18,8 @@ let vs
 let ve
 let oboEvents
 let VisitModel
+let db
+let logger
 
 describe('viewer events', () => {
 	beforeAll(() => {})
@@ -25,6 +29,8 @@ describe('viewer events', () => {
 		vs = oboRequire('viewer/viewer_state')
 		oboEvents = oboRequire('obo_events')
 		VisitModel = oboRequire('models/visit')
+		db = oboRequire('db')
+		logger = oboRequire('logger')
 	})
 	afterEach(() => {})
 
@@ -34,7 +40,9 @@ describe('viewer events', () => {
 		ve = oboRequire('viewer_events')
 		expect(oboEvents.on).toBeCalledWith('client:nav:open', expect.any(Function))
 		expect(oboEvents.on).toBeCalledWith('client:nav:close', expect.any(Function))
-		expect(oboEvents.on).toHaveBeenCalledTimes(2)
+		expect(oboEvents.on).toBeCalledWith('client:nav:redAlert:enable', expect.any(Function))
+		expect(oboEvents.on).toBeCalledWith('client:nav:redAlert:disable', expect.any(Function))
+		expect(oboEvents.on).toHaveBeenCalledTimes(4)
 	})
 
 	test('executes next when included to support express middleware', () => {
@@ -93,6 +101,61 @@ describe('viewer events', () => {
 				false,
 				'mockResourceLinkId'
 			)
+		})
+	})
+
+	test('client:nav:redAlert:enable', () => {
+		expect.hasAssertions()
+		ve = oboRequire('viewer_events')
+
+		const [eventName, callback] = oboEvents.on.mock.calls[2]
+		expect(eventName).toBe('client:nav:redAlert:enable')
+		expect(callback).toHaveLength(1) // callback has 1 argument
+
+		db.none.mockResolvedValueOnce({
+			test: 'test'
+		})
+
+		expect(vs.set).not.toHaveBeenCalled()
+		return callback(mockEvent).then(() => {
+			expect(db.none).toBeCalled()
+		})
+	})
+
+	test('client:nav:redAlert:disable', () => {
+		expect.hasAssertions()
+		ve = oboRequire('viewer_events')
+
+		const [eventName, callback] = oboEvents.on.mock.calls[3]
+		expect(eventName).toBe('client:nav:redAlert:disable')
+		expect(callback).toHaveLength(1) // callback has 1 argument
+
+		db.none.mockResolvedValueOnce({
+			test: 'test'
+		})
+
+		expect(vs.set).not.toHaveBeenCalled()
+		return callback(mockEvent).then(() => {
+			expect(db.none).toBeCalled()
+		})
+	})
+
+	test('client:nav:redAlert:disable error', () => {
+		expect.assertions(4)
+		oboRequire('viewer_events')
+
+		const [eventName, callback] = oboEvents.on.mock.calls[3]
+		expect(eventName).toBe('client:nav:redAlert:disable')
+		expect(callback).toHaveLength(1) // callback has 1 argument
+
+		db.none.mockRejectedValueOnce('snail')
+
+		const testPayload = { payload: { to: 'banana' } }
+
+		expect(logger.error).not.toHaveBeenCalled()
+
+		return callback(testPayload).then(() => {
+			expect(logger.error).toBeCalled()
 		})
 	})
 })

--- a/packages/app/obojobo-express/migrations/20200227175423-create-red-alert-status.js
+++ b/packages/app/obojobo-express/migrations/20200227175423-create-red-alert-status.js
@@ -1,0 +1,61 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+	dbm = options.dbmigrate
+	type = dbm.dataType
+	seed = seedLink
+}
+
+exports.up = function(db) {
+	return db
+		.createTable('red_alert_status', {
+			id: {
+				type: 'UUID',
+				primaryKey: true,
+				defaultValue: new String('uuid_generate_v4()')
+			},
+			user_id: { type: 'bigint', notNull: true },
+			created_at: {
+				type: 'timestamp WITH TIME ZONE',
+				notNull: true,
+				defaultValue: new String('now()')
+			},
+			updated_at: {
+				type: 'timestamp WITH TIME ZONE',
+				notNull: true,
+				defaultValue: new String('now()')
+			},
+			draft_id: { type: 'UUID', notNull: true },
+			is_enabled: { type: 'boolean', notNull: true }
+		})
+		.then(() => {
+			db.addIndex('red_alert_status', 'red_alert_status_user_index', ['user_id'])
+		})
+		.then(() => {
+			db.addIndex('red_alert_status', 'red_alert_status_draft_index', ['draft_id'])
+		})
+		.then(result => {
+			return db.addIndex(
+				'red_alert_status',
+				'red_alert_status_unique',
+				['user_id', 'draft_id'],
+				true
+			)
+		})
+}
+
+exports.down = function(db) {
+	return db.dropTable('red_alert_status')
+}
+
+exports._meta = {
+	version: 1
+}

--- a/packages/app/obojobo-express/routes/api/visits.js
+++ b/packages/app/obojobo-express/routes/api/visits.js
@@ -1,3 +1,4 @@
+const db = oboRequire('db')
 const express = require('express')
 const router = express.Router()
 const logger = oboRequire('logger')
@@ -51,7 +52,9 @@ router
 		let viewState
 		let visitStartReturnExtensionsProps
 		let launch
+		let isRedAlertEnabled = false
 
+		const userId = req.currentUser.id
 		const draftId = req.currentDocument.draftId
 		const visitId = req.body.visitId
 		logger.log(`VISIT: Begin start visit for visitId="${visitId}", draftId="${draftId}"`)
@@ -60,6 +63,23 @@ router
 			.getCurrentVisitFromRequest()
 			.catch(() => {
 				throw 'Unable to start visit, visitId is no longer valid'
+			})
+			.then(() =>
+				db.oneOrNone(
+					`
+						SELECT is_enabled FROM red_alert_status
+						WHERE
+							user_id = $[userId]
+							AND draft_id = $[draftId]
+					`,
+					{
+						userId,
+						draftId
+					}
+				)
+			)
+			.then(result => {
+				if (result) isRedAlertEnabled = result.is_enabled
 			})
 			.then(() =>
 				Promise.all([
@@ -131,6 +151,7 @@ router
 				req.session.visitSessions[draftId] = true
 
 				res.success({
+					isRedAlertEnabled,
 					visitId,
 					isPreviewing: req.currentVisit.is_preview,
 					lti,

--- a/packages/app/obojobo-express/viewer_events.js
+++ b/packages/app/obojobo-express/viewer_events.js
@@ -1,6 +1,8 @@
 const oboEvents = oboRequire('obo_events')
 const viewerState = oboRequire('viewer/viewer_state')
 const VisitModel = oboRequire('models/visit')
+const db = oboRequire('db')
+const logger = oboRequire('logger')
 
 oboEvents.on('client:nav:open', event => {
 	return setNavOpen(event.userId, event.draftId, event.contentId, true, event.visitId)
@@ -9,6 +11,45 @@ oboEvents.on('client:nav:open', event => {
 oboEvents.on('client:nav:close', event => {
 	return setNavOpen(event.userId, event.draftId, event.contentId, false, event.visitId)
 })
+
+oboEvents.on('client:nav:redAlert:enable', event => {
+	return toggleRedAlert(event)
+})
+
+oboEvents.on('client:nav:redAlert:disable', event => {
+	return toggleRedAlert(event)
+})
+
+const toggleRedAlert = event => {
+	const userId = event.userId
+	const draftId = event.draftId
+	const isRedAlertEnabled = event.payload.to
+	// const isRedAlertEnabled = 'false'
+	const createdAtTime = new Date().toISOString()
+	const updatedAtTime = new Date().toISOString()
+	return db
+		.none(
+			`
+				INSERT INTO red_alert_status
+				(user_id, created_at, updated_at, draft_id, is_enabled)
+				VALUES($[userId], $[createdAtTime], $[updatedAtTime], $[draftId], $[isRedAlertEnabled])
+				ON CONFLICT (draft_id, user_id) DO UPDATE
+				SET is_enabled = $[isRedAlertEnabled], updated_at = $[updatedAtTime]
+				WHERE red_alert_status.user_id = $[userId] AND
+				red_alert_status.draft_id = $[draftId]
+			`,
+			{
+				userId,
+				createdAtTime,
+				updatedAtTime,
+				draftId,
+				isRedAlertEnabled
+			}
+		)
+		.catch(error => {
+			logger.error('DB UNEXPECTED on red_alert_status.set', error, error.toString())
+		})
+}
 
 const setNavOpen = (userId, draftId, contentId, value, visitId) => {
 	return VisitModel.fetchById(visitId).then(visit => {


### PR DESCRIPTION
This is a merge request, but just for my own testing / investigation.

* Adds Red Alert mode functionality
* Migration creates additional table `red_alert_status` in the database to store status of Red Alert mode
* Enabling and disabling Red Alert mode is logged in `events` table
* Test coverage at 100%